### PR TITLE
Allow ro. properties to have arbitrary lengths

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -64,7 +64,7 @@ def validate(prop):
   buildprops = prop.to_dict()
   for key, value in buildprops.iteritems():
     # Check build properties' length.
-    if len(value) > PROP_VALUE_MAX:
+    if len(value) > PROP_VALUE_MAX and not key.startswith("ro."):
       check_pass = False
       sys.stderr.write("error: %s cannot exceed %d bytes: " %
                        (key, PROP_VALUE_MAX))


### PR DESCRIPTION
Bug: 23102347
Bug: 34954705
Test: provide a fingerprint >92 characters long and see that it
      successfully works

Change-Id: Ida9ffd5266acb3b432b208780804a08e8f7391b4